### PR TITLE
Fix last_wake_time reset to current time on each loop iteration.

### DIFF
--- a/main/app_main.c
+++ b/main/app_main.c
@@ -174,8 +174,6 @@ _Noreturn void app_main()
 
         while (1)
         {
-            last_wake_time = xTaskGetTickCount();
-
             ds18b20_convert_all(owb);
 
             // In this application all devices use the same resolution,


### PR DESCRIPTION
Thank you for the example and this wonderful library, they've been very helpful.

There's a small issue with using `vTaskDelayUntil`, which (I think?) makes it perform the same as `vTaskDelay`: the last wake time is reset on each measurement loop iteration.

If we look at the FreeRTOS docs for this function:

    @param pxPreviousWakeTime Pointer to a variable that holds the time at which the
    task was last unblocked.  The variable must be initialised with the current time
    prior to its first use (see the example below).  Following this the variable is
    automatically updated within vTaskDelayUntil ().

and the accompanying example:

```c
// Perform an action every 10 ticks.
void vTaskFunction( void * pvParameters )
{
    TickType_t xLastWakeTime;
    const TickType_t xFrequency = 10;
    
    // Initialise the xLastWakeTime variable with the current time.
    xLastWakeTime = xTaskGetTickCount ();
    for( ;; )
    {
           // Wait for the next cycle.
           vTaskDelayUntil( &xLastWakeTime, xFrequency );
    
           // Perform action here.
    }
}
```